### PR TITLE
Use main branch instead of master in chart-releaser-action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,6 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@master
+        uses: helm/chart-releaser-action@main
         env:
           CR_TOKEN: '${{ secrets.CR_TOKEN }}'


### PR DESCRIPTION
Signed-off-by: Richard Marston <rmarston@eonerc.rwth-aachen.de>