### PR TITLE
change token to builtin

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,4 +25,4 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@main
         env:
-          CR_TOKEN: '${{ secrets.CR_TOKEN }}'
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Use the `secrets.GITHUB_TOKEN` instead of defined `secrets.CR_TOKEN` which seems to have expired. 