### PR TITLE
change chart tag due to collision

### DIFF
--- a/charts/dpsim-iec104-demo/Chart.yaml
+++ b/charts/dpsim-iec104-demo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: dpsim-demo
+name: dpsim-iec104-demo
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
The new chart for iec104 was tagged as dpsim-demo-0.1.0 which already exists. It is now tagged dpsim-iec104-demo-0.1.0.